### PR TITLE
Removed useless fields in the trigger declaration

### DIFF
--- a/KafkaTwitterTrigger/function.json
+++ b/KafkaTwitterTrigger/function.json
@@ -1,13 +1,9 @@
 {
   "bindings": [
     {
-      "type": "kafkaTrigger",
-      "direction": "in",
-      "name": "event",
       "topic": "twitter",
       "brokerList": "kafka-cp-kafka-headless.default.svc.cluster.local:9092",
-      "consumerGroup": "functions",
-      "dataType": "binary"
+      "consumerGroup": "functions"
     }
   ],
   "scriptFile": "../dist/KafkaTwitterTrigger/index.js"

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -47,13 +47,9 @@ spec:
   triggers:
   - type: kafka
     metadata:
-      type: kafkaTrigger
-      direction: in
-      name: event
       topic: twitter
       brokerList: kafka-cp-kafka-headless.default.svc.cluster.local:9092
       consumerGroup: functions
-      dataType: binary
       lagThreshold: '5'
 ---
 


### PR DESCRIPTION
This PR removes some fields from the Kafka trigger metadata which are not handled by the related scaler.